### PR TITLE
Fixing buienradar data URI

### DIFF
--- a/buienradar.js
+++ b/buienradar.js
@@ -56,7 +56,7 @@ module.exports = function (RED) {
 
         //node.log("Requesting buienradar update ...");
 
-        var url = "https://xml.buienradar.nl";
+        var url = "https://data.buienradar.nl/1.0/feed/xml";
         if (url) {
             node.status({ fill: "blue", shape: "dot", text: "Ophalen weergegevens" });
             var req = https.get(url, function (res) {


### PR DESCRIPTION
It seems that the URI to access XML data from the Buienradar API was changed to https://data.buienradar.nl/1.0/feed/xml. The old uri no longer returns a result in NodeRED, quiet possibly because this starts a redirect and the NodeJS request might not be so keen on allowing that. Changing the URI to the new format fixed the problem.